### PR TITLE
[ENHANCEMENT] 認可の処理方法を変更

### DIFF
--- a/src/components/user/user.resolver.mutation.spec.ts
+++ b/src/components/user/user.resolver.mutation.spec.ts
@@ -35,9 +35,9 @@ describe('User Mutation Resolver Test', () => {
     mockedUserService.update.mockResolvedValue(fakeUser);
 
     const expectUser = fakeUser;
-    await expect(
-      userQuery.updateUser({ where: { id: expectUser.id }, data: { id: { set: expectUser.id }, name: { set: expectUser.name } } }),
-    ).resolves.toEqual(expectUser);
+    await expect(userQuery.updateUser({ where: { id: expectUser.id }, data: { id: expectUser.id, name: expectUser.name } })).resolves.toEqual(
+      expectUser,
+    );
   });
 
   test('deleteUser', async () => {

--- a/src/components/user/user.resolver.mutation.ts
+++ b/src/components/user/user.resolver.mutation.ts
@@ -27,7 +27,7 @@ export default class UserMutation {
     }
 
     const user = await this.service.update(args);
-    await this.firebaseService.adminAuth.updateUser(args.where.id, { displayName: args.data.name?.set });
+    await this.firebaseService.adminAuth.updateUser(args.where.id, { displayName: args.data.name });
 
     return user;
   }

--- a/src/guards/auth.guard.ts
+++ b/src/guards/auth.guard.ts
@@ -20,14 +20,13 @@ export default class AuthGuard implements CanActivate {
     let authorization: string | undefined;
     let uid: string | undefined;
     context.getArgs().forEach((arg) => {
-      if (arg && arg.authorization) {
-        authorization = arg.authorization;
-      }
-      if (arg && arg.data && arg.data.id) {
-        uid = arg.data.id;
-      }
-      if (arg && arg.where && arg.where.id) {
-        uid = arg.where.id;
+      if (arg && arg.req && arg.req.headers) {
+        if (arg.req.headers.authorization) {
+          authorization = arg.req.headers.authorization;
+        }
+        if (arg.req.headers.uid) {
+          uid = arg.req.headers.uid;
+        }
       }
     });
 

--- a/src/libs/prisma/schema.prisma
+++ b/src/libs/prisma/schema.prisma
@@ -3,9 +3,13 @@ generator client {
 }
 
 generator nestgraphql {
-  provider          = "prisma-nestjs-graphql"
-  output            = "./generated"
-  outputFilePattern = "{model}/{name}/{type}.ts"
+  provider                              = "prisma-nestjs-graphql"
+  output                                = "./generated"
+  outputFilePattern                     = "{model}/{name}/{type}.ts"
+  noAtomicOperations                    = true
+  purgeOutput                           = true
+  noTypeId                              = true
+  requireSingleFieldsInWhereUniqueInput = ture
 }
 
 datasource db {

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -179,6 +179,6 @@ describe('E2E Test', () => {
     console.log(createdUser.data);
     console.log(createdUser.errors);
 
-    adminAuth.deleteUser(testUser.uid);
+    await adminAuth.deleteUser(testUser.uid);
   });
 });

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -82,6 +82,7 @@ describe('E2E Test', () => {
         },
       })
       .set('authorization', testToken)
+      .set('uid', testUser.uid)
       .expectNoErrors();
 
     expect(createdUser.response.status).toBe(200);
@@ -102,13 +103,14 @@ describe('E2E Test', () => {
       )
       .variables({
         data: {
-          name: { set: `updated ${testUser.displayName}` },
+          name: `updated ${testUser.displayName}`,
         },
         where: {
           id: testUser.uid,
         },
       })
       .set('authorization', testToken)
+      .set('uid', testUser.uid)
       .expectNoErrors();
 
     expect(updatedUser.response.status).toBe(200);
@@ -133,6 +135,7 @@ describe('E2E Test', () => {
         },
       })
       .set('authorization', testToken)
+      .set('uid', testUser.uid)
       .expectNoErrors();
 
     expect(deletedUser.response.status).toBe(200);
@@ -169,7 +172,8 @@ describe('E2E Test', () => {
           name: testUser.displayName,
         },
       })
-      .set('authorization', testToken);
+      .set('authorization', testToken)
+      .set('uid', 'invalid-fake-uid');
 
     expect(createdUser.data).toEqual(null);
     console.log(createdUser.data);


### PR DESCRIPTION
Authorizationヘッダに付与されたtokenの持ち主とGraphQL Operationの引数にあるuidの持ち主の一致を確認することで認可していた処理を、Authorizationヘッダと新たにuidヘッダを参照してするように修正。
これにより、より厳重かつ柔軟なセキュリティを得ることができると考えられる。